### PR TITLE
Patch recipe lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,3 @@ bin/
 # fabric
 
 run/
-runserver/

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ bin/
 # fabric
 
 run/
+runserver/

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs=-Xmx3G
 	# check these on https://fabricmc.net/develop
 	minecraft_version=1.19.2
 	yarn_mappings=1.19.2+build.1
-	loader_version=0.14.9
+	loader_version=0.14.10
 
 # Mod Properties
 	mod_version = 1.0.2
@@ -13,4 +13,5 @@ org.gradle.jvmargs=-Xmx3G
 	archives_base_name = Alchemistry
 
 # Dependencies
-	fabric_version=0.59.0+1.19.2
+	fabric_version=0.76.0+1.19.2
+

--- a/src/main/java/com/smashingmods/alchemistry/api/blockentity/AbstractReactorBlockEntity.java
+++ b/src/main/java/com/smashingmods/alchemistry/api/blockentity/AbstractReactorBlockEntity.java
@@ -103,12 +103,8 @@ public abstract class AbstractReactorBlockEntity extends AbstractInventoryBlockE
                         .findFirst()
                         .ifPresent(blockPos -> {
                             BlockState energyState = world.getBlockState(blockPos);
-<<<<<<< Updated upstream
                             world.setBlockState(blockPos, Blocks.AIR.getDefaultState());
                             world.setBlockState(blockPos, energyState);
-=======
-                            world.setBlockState(blockPos, energyState, 7);
->>>>>>> Stashed changes
                             setEnergyFound(true);
                             reactorEnergyBlockEntity = (ReactorEnergyBlockEntity) world.getBlockEntity(blockPos);
                         });
@@ -124,7 +120,7 @@ public abstract class AbstractReactorBlockEntity extends AbstractInventoryBlockE
                             BlockState inputState = world.getBlockState(blockPos);
                             world.setBlockState(blockPos, Blocks.AIR.getDefaultState(), 7);
                             world.setBlockState(blockPos, inputState, 7);
-                            setInputFound(true);
+                            inputFound = true;
                             reactorInputBlockEntity = (ReactorInputBlockEntity) world.getBlockEntity(blockPos);
                         });
             } else {
@@ -140,7 +136,7 @@ public abstract class AbstractReactorBlockEntity extends AbstractInventoryBlockE
                             BlockState outputState = world.getBlockState(blockPos);
                             world.setBlockState(blockPos, Blocks.AIR.getDefaultState(), 7);
                             world.setBlockState(blockPos, outputState, 7);
-                            setOutputFound(true);
+                            outputFound = true;
                             reactorOutputBlockEntity = (ReactorOutputBlockEntity) world.getBlockEntity(blockPos);
                         });
             } else {

--- a/src/main/java/com/smashingmods/alchemistry/api/blockentity/AbstractReactorBlockEntity.java
+++ b/src/main/java/com/smashingmods/alchemistry/api/blockentity/AbstractReactorBlockEntity.java
@@ -103,8 +103,12 @@ public abstract class AbstractReactorBlockEntity extends AbstractInventoryBlockE
                         .findFirst()
                         .ifPresent(blockPos -> {
                             BlockState energyState = world.getBlockState(blockPos);
+<<<<<<< Updated upstream
                             world.setBlockState(blockPos, Blocks.AIR.getDefaultState());
                             world.setBlockState(blockPos, energyState);
+=======
+                            world.setBlockState(blockPos, energyState, 7);
+>>>>>>> Stashed changes
                             setEnergyFound(true);
                             reactorEnergyBlockEntity = (ReactorEnergyBlockEntity) world.getBlockEntity(blockPos);
                         });
@@ -120,7 +124,7 @@ public abstract class AbstractReactorBlockEntity extends AbstractInventoryBlockE
                             BlockState inputState = world.getBlockState(blockPos);
                             world.setBlockState(blockPos, Blocks.AIR.getDefaultState(), 7);
                             world.setBlockState(blockPos, inputState, 7);
-                            inputFound = true;
+                            setInputFound(true);
                             reactorInputBlockEntity = (ReactorInputBlockEntity) world.getBlockEntity(blockPos);
                         });
             } else {
@@ -136,7 +140,7 @@ public abstract class AbstractReactorBlockEntity extends AbstractInventoryBlockE
                             BlockState outputState = world.getBlockState(blockPos);
                             world.setBlockState(blockPos, Blocks.AIR.getDefaultState(), 7);
                             world.setBlockState(blockPos, outputState, 7);
-                            outputFound = true;
+                            setOutputFound(true);
                             reactorOutputBlockEntity = (ReactorOutputBlockEntity) world.getBlockEntity(blockPos);
                         });
             } else {

--- a/src/main/java/com/smashingmods/alchemistry/common/block/combiner/CombinerBlockEntity.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/combiner/CombinerBlockEntity.java
@@ -72,6 +72,22 @@ public class CombinerBlockEntity extends AbstractInventoryBlockEntity {
 
     @Override
     public boolean canInsert(int slot, ItemStack stack, @Nullable Direction side) {
+        if (isRecipeLocked() && currentRecipe != null) {
+            int validInsert = 0;
+            for (int i = 0; i < currentRecipe.getIngredients().size(); i++) {
+                if (currentRecipe.getIngredients().get(i).test(stack)) {
+                    validInsert++;
+                }
+            }
+            int totalItems = 0;
+            ItemStack item;
+            for (int i = 0; i < getItems().size(); i++) {
+                item = getItems().get(i);
+                totalItems += item.isOf(stack.getItem()) ? item.getCount() : 0;
+            }
+            return slot < OUTPUT_SLOT_INDEX && totalItems < validInsert * stack.getMaxCount();
+        }
+
         return slot < OUTPUT_SLOT_INDEX;
     }
 

--- a/src/main/java/com/smashingmods/alchemistry/common/block/compactor/CompactorBlockEntity.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/compactor/CompactorBlockEntity.java
@@ -66,6 +66,11 @@ public class CompactorBlockEntity extends AbstractInventoryBlockEntity {
 
     @Override
     public boolean canInsert(int slot, ItemStack stack, @Nullable Direction side) {
+        if (isRecipeLocked() && currentRecipe != null) {
+            // there is only one input slot in recipe no matter what
+            boolean validInsert = currentRecipe.getIngredients().get(0).test(stack);
+            return validInsert && slot == INPUT_SLOT_INDEX;
+        }
         return slot == INPUT_SLOT_INDEX;
     }
 

--- a/src/main/java/com/smashingmods/alchemistry/common/block/dissolver/DissolverBlockEntity.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/dissolver/DissolverBlockEntity.java
@@ -62,6 +62,12 @@ public class DissolverBlockEntity extends AbstractInventoryBlockEntity {
 
     @Override
     public boolean canInsert(int slot, ItemStack stack, @Nullable Direction side) {
+        if (isRecipeLocked() && currentRecipe != null) {
+            // there is only one input slot in recipe no matter what
+            boolean validInsert = currentRecipe.getIngredients().get(0).test(stack);
+            return validInsert && slot == 0;
+        }
+
         return slot == 0;
     }
 

--- a/src/main/java/com/smashingmods/alchemistry/common/block/reactor/ReactorInputBlockEntity.java
+++ b/src/main/java/com/smashingmods/alchemistry/common/block/reactor/ReactorInputBlockEntity.java
@@ -37,8 +37,29 @@ public class ReactorInputBlockEntity extends BlockEntity implements ImplementedI
     public boolean canInsert(int slot, ItemStack stack, @org.jetbrains.annotations.Nullable Direction side) {
         if (controller != null) {
             if (controller.getReactorType() == ReactorType.FISSION) {
+
+                if (controller.isRecipeLocked() && controller.getRecipe() != null) {
+                    // there is only one input slot in recipe no matter what
+                    boolean validInsert = controller.getRecipe().getIngredients().get(0).test(stack);
+                    return validInsert && slot == 0;
+                }
                 return slot == 0;
             } else if (controller.getReactorType() == ReactorType.FUSION) {
+                if (controller.isRecipeLocked() && controller.getRecipe() != null) {
+                    int validInsert = 0;
+                    for (int i = 0; i < controller.getRecipe().getIngredients().size(); i++) {
+                        if (controller.getRecipe().getIngredients().get(i).test(stack)) {
+                            validInsert++;
+                        }
+                    }
+                    int totalItems = 0;
+                    ItemStack item;
+                    for (int i = 0; i < getItems().size(); i++) {
+                        item = getItems().get(i);
+                        totalItems += item.isOf(stack.getItem()) ? item.getCount() : 0;
+                    }
+                    return slot < 2 && totalItems < validInsert * stack.getMaxCount();
+                }
                 return slot != 2;
             }
         }


### PR DESCRIPTION
Fix #3, so now hoppers, pipes, etc. are limited in what they can transfer if the recipe lock is enabled.